### PR TITLE
Fixes #43: Login/logout buttons both printing to DOM

### DIFF
--- a/javascripts/DOMInteraction.js
+++ b/javascripts/DOMInteraction.js
@@ -161,3 +161,15 @@ $(document).on("click", ".starRating", function() {
     }
     fbFactory.updateUserMovie(movieObj, updatedMovieId);
 });
+
+// Listens for firebase's onAuthStateChanged event, toggling login/logout btns
+// accordingly
+firebase.auth().onAuthStateChanged(() => {
+  if(firebase.auth().currentUser !== null){
+    $("#login").hide();
+    $("#logout").show();
+  } else if(firebase.auth().currentUser === null){
+    $("#logout").hide();
+    $("#login").show();
+  }
+});

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -26,3 +26,7 @@ header{
         margin: auto;
     }
 }
+
+#logout, #login {
+  display: none;
+}


### PR DESCRIPTION
## Fixes #43 : Login/Logout buttons are both printing to DOM

### Functions added
- Adds to `DOMinteraction.js` Firebase's `onAuthStateChanged` event listener
- When fired, listener checks firebase's `auth().currentUser` property, printing login/logout button accordingly

### Styling
- Initially. **both** buttons are set to `display: none` in `main.scss`, with firebase `onAuthStateChanged` changing display accordingly