### PR TITLE
Fixes #28: 'Favorites' button now prints 'favorite' movies

### DIFF
--- a/javascripts/DOMInteraction.js
+++ b/javascripts/DOMInteraction.js
@@ -133,6 +133,15 @@ $('#displayWatched').on('click', function () {
         });
 });
 
+$('#displayFavorites').on('click', function () {
+  $('#findMoviesContainer').html('');
+  let display = 'favorites';
+  fbFactory.getMovies(firebase.auth().currentUser.uid)
+  .then(data => {
+    controller.startUserMovies(data, display);
+  });
+});
+
 /******* STAR RATING ***********/
 
 $(document).on("click", ".starRating", function() {

--- a/javascripts/controller.js
+++ b/javascripts/controller.js
@@ -30,6 +30,9 @@ let checkWatched = (movieObject, display) => {
   if (movieObject.watched === true && display === 'watched') {
     output.watchedMovies(movieObject, movieObject.actors, movieObject.fbKey);
     output.addHighlightedStars(movieObject);
+  } else if (movieObject.watched === true && display === 'favorites' && movieObject.starRating > 6) {
+    output.watchedMovies(movieObject, movieObject.actors, movieObject.fbKey);
+    output.addHighlightedStars(movieObject);
   } else if (movieObject.watched === false && display === 'unwatched') {
     output.watchListMovies(movieObject, movieObject.actors, movieObject.fbKey);
   }


### PR DESCRIPTION
## Fixes #28 : 'Show Favorites' button doesn't do anything

This follows the same design pattern applied to clicking on 'Show Unwatched'/'Show Watched' toggles

### Functions
- Adds event listener in `DOMinteraction.js` for user clicking on `#displayFavorites` toggle
- Fires AJAX call in `fbFactory.js`, passing data into `controller.js`, which fires another AJAX call & finally passes that compiled data to `checkWatched` in `controller.js`
- Adds a new condition in `checkWatched` that filters for movies with a `starRating` higher than 6